### PR TITLE
Small bug fix

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -76,6 +76,7 @@ function inputQueryOnChangeHandler() {
       aiInsightsButton.style.display = 'none'
       ado_create_work_item.style.display = 'none'
       insightsContent.style.display = 'none'
+      createWorkItemContent.style.display='none'
       engMs_search.style.display = 'none'
       for (const [key, value] of Object.entries(configJson)) {
         configJson[key] = replacer(value, {


### PR DESCRIPTION
This pull request includes a change in the `src/popup.js` file where the `inputQueryOnChangeHandler()` function now hides the `createWorkItemContent` element.

* [`src/popup.js`](diffhunk://#diff-3c22697f71643bb8287c56e99e71595d2253122520883f9319e9b27140da5019R79): Updated the `inputQueryOnChangeHandler()` function to hide the `createWorkItemContent` element.